### PR TITLE
Fixed FormManagerFactory in ZF > 2.4

### DIFF
--- a/src/StrokerForm/Factory/FormManagerFactory.php
+++ b/src/StrokerForm/Factory/FormManagerFactory.php
@@ -19,13 +19,17 @@ class FormManagerFactory implements \Zend\ServiceManager\FactoryInterface
      * Create service
      *
      * @param  ServiceLocatorInterface $serviceLocator
-     * @return mixed
+     * @return FormManager
      */
     public function createService(ServiceLocatorInterface $serviceLocator)
     {
         /** @var $moduleOptions \StrokerForm\Options\ModuleOptions  */
         $moduleOptions = $serviceLocator->get('StrokerForm\Options\ModuleOptions');
-
-        return new FormManager($moduleOptions->getForms());
+        // init FormManager
+        $fromManager = new FormManager($moduleOptions->getForms());
+        // set serviceLocator to FormManager
+        $formManager->setServiceLocator($serviceLocator);
+        
+        return $formManager;
     }
 }


### PR DESCRIPTION
- added serviceLocator to FormManager to fix "ServiceLocatorAwareInterface is deprecated and will be removed in version 3.0" Error